### PR TITLE
Fix/ eslint-config-prettier installation

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,7 @@
     "node": true,
     "es2021": true
   },
-  "extends": ["airbnb-base"],
+  "extends": ["airbnb-base", "prettier"],
   "parserOptions": {
     "ecmaVersion": 12,
     "sourceType": "module"


### PR DESCRIPTION
O repositório do esling-config-prettier diz que é necessário adicionar "prettier" ao array "extends" do arquivo .eslintrc.* .
Também é dito que "prettier" deve ser o último item desse arary.
Sem essa configuração, mesmo que o pacote esteja instalado o prettier continua dando conflito com o eslint.

Fonte:
https://github.com/prettier/eslint-config-prettier#installation